### PR TITLE
 apt module with a list is more efficient

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,18 +2,16 @@
 ---
 - name: install dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ logcheck_dependencies }}"
     state: latest
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: '{{ logcheck_dependencies }}'
   tags: [configuration, logcheck, logcheck-dependencies]
 
 - name: install additional
   apt:
-    name: "{{ item }}"
+    name: "{{ logcheck_install }}"
     state: latest
-  with_items: '{{ logcheck_install }}'
   tags: [configuration, logcheck, logcheck-install]
 
 - name: update configuration file - /etc/logcheck/logcheck.conf


### PR DESCRIPTION
It also avoids a deprecation warning. Certainly works 2.5 upwards. Dokumentation for 2.7 which deprecated the loop suggests it works since 2.3

fixes #10
